### PR TITLE
Updated pegjs, through2, and mocha versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "iojs"
+  - "4"
+  - "5"
+  - "6"
+  - "node"

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (opts) {
 		var filePath = file.path;
 
 		try {
-      file.contents = new Buffer(pegjs.buildParser(file.contents.toString(), options));
+      file.contents = new Buffer(pegjs.generate(file.contents.toString(), options));
       file.path = gutil.replaceExtension(file.path, '.js');
 			this.push(file);
 		} catch (err) {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "gulp-util": "^3.0.6",
     "object-assign": "^4.0.1",
-    "pegjs": "^0.8.0",
-    "through2": "^0.6.5"
+    "pegjs": "^0.10.0",
+    "through2": "^2.0.1"
   },
   "devDependencies": {
     "assert": "^1.3.0",
-    "mocha": "^2.2.5"
+    "mocha": "^3.0.2"
   }
 }


### PR DESCRIPTION
_Updated packages._ If you could merge this and release a new version on NPM that would be spectacular.

Also, it would be helpful if you could add a slight bit of documentation about `options`—the reason I updated these packages was because I assumed the older version of pegjs was the reason the gulp-compiled parser wasn't working. Turns out I needed `{ format: 'commonjs' }` to match what compiling by the command line was giving me.

Thanks for providing this useful package!
