### PR TITLE
hardcoded default output format

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (opts) {
 		}
 
     // always generate source code of parser
-		var options = assign({ output: 'source' }, opts);
+		var options = assign({ output: 'source', format: 'commonjs' }, opts);
 
 		var filePath = file.path;
 


### PR DESCRIPTION
"commonjs" should be the default instead of "bare" - just like in pegjs CLI tool.

Also, please consider fixing the indentation to be either space- or tab-only.